### PR TITLE
chore(deps): bump up nitro to version 0.28.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ A high-performance file system module for React Native that provides native-spee
 
 ```bash
 # Using bun (recommended)
-bun add react-native-nitro-fs react-native-nitro-modules@0.27.2
+bun add react-native-nitro-fs react-native-nitro-modules
 
 # Using npm
-npm install react-native-nitro-fs react-native-nitro-modules@0.27.2
+npm install react-native-nitro-fs react-native-nitro-modules
 
 # Using yarn
-yarn add react-native-nitro-fs react-native-nitro-modules@0.27.2
+yarn add react-native-nitro-fs react-native-nitro-modules
 ```
 
 ### iOS Setup

--- a/bun.lock
+++ b/bun.lock
@@ -10,11 +10,11 @@
         "@types/jest": "^29.5.12",
         "@types/react": "^19.1.0",
         "conventional-changelog-conventionalcommits": "^9.1.0",
-        "nitro-codegen": "^0.28.0",
+        "nitro-codegen": "^0.28.1",
         "react": "19.1.0",
         "react-native": "0.81.0",
         "react-native-builder-bob": "^0.37.0",
-        "react-native-nitro-modules": "^0.28.0",
+        "react-native-nitro-modules": "^0.28.1",
         "semantic-release": "^24.2.7",
         "typescript": "^5.8.3",
       },
@@ -30,7 +30,7 @@
       "dependencies": {
         "react": "19.1.0",
         "react-native": "0.81.0",
-        "react-native-nitro-modules": "^0.28.0",
+        "react-native-nitro-modules": "^0.28.1",
         "react-native-safe-area-context": "^5.5.2",
       },
       "devDependencies": {
@@ -1397,7 +1397,7 @@
 
     "nerf-dart": ["nerf-dart@1.0.0", "", {}, "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g=="],
 
-    "nitro-codegen": ["nitro-codegen@0.28.0", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.28.0", "ts-morph": "^25.0.0", "yargs": "^17.7.2", "zod": "^4.0.5" }, "bin": { "nitro-codegen": "lib/index.js" } }, "sha512-sFvLbQQXGKyy3Xer9Oz4J6+KXe4VeKGPzIy893tG65Dfn43rrez849ZG/o/Y3iD2M637ROZeCtGFqQM8mIIo6w=="],
+    "nitro-codegen": ["nitro-codegen@0.28.1", "", { "dependencies": { "chalk": "^5.3.0", "react-native-nitro-modules": "^0.28.1", "ts-morph": "^25.0.0", "yargs": "^17.7.2", "zod": "^4.0.5" }, "bin": { "nitro-codegen": "lib/index.js" } }, "sha512-o0NRo9xCmh+yNNS391STA+45r+DFW9z1aeGyn/OKXdj5vwzC2ZPTRJBtcGpHPKRbN5gEuwTgD5RIuRM8BApx4Q=="],
 
     "nocache": ["nocache@3.0.4", "", {}, "sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw=="],
 
@@ -1561,7 +1561,7 @@
 
     "react-native-nitro-fs-example": ["react-native-nitro-fs-example@workspace:example"],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.28.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-SR5fpEOxuzqObowLzwrAU7Pv9Kq+AcxKBTCprMcsaiNlURhex2R8T8moSU/hpZO8Vuf3iomdkzEVEIO8udSZ/w=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.28.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-+H9ORJ2WIF17ytQS3MmXJnZnGjp/cSFNFgVkX+6f+uGGrCebFzPyyoks3mPIQ0C4rYuI4sv4ltuR0jQCnPjlqw=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-tJas3YOdsuCg3kepCTGF3LWZp9onMbb9Agju2xfs2kRX8d/5TMUPmupBpjerk/B7Tv/zeJnk+qp5neA96Y0otQ=="],
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.0):
     - hermes-engine/Pre-built (= 0.81.0)
   - hermes-engine/Pre-built (0.81.0)
-  - NitroFS (0.6.0):
+  - NitroFS (0.6.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -38,7 +38,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - NitroModules (0.28.0):
+  - NitroModules (0.28.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2613,8 +2613,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: e7491a2038f2618c8cd444ed411a6deb350a3742
-  NitroFS: 20e05553bba5a59ea1a1ba4c4cedde70a7f6a75c
-  NitroModules: 54b9c7efd517b142c015a4a8dff49c779191627c
+  NitroFS: 98b0accba90627083c71c92021debdf4802129b9
+  NitroModules: 58f33f6f7137aa5461298a0495b3e7a3a6fdea9d
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 0735ab4f6b3ec93a7f98187b5da74d7916e2cf4c
   RCTRequired: 8fcc7801bfc433072287b0f24a662e2816e89d0c
@@ -2684,4 +2684,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f287a9473ffda722086de7168bf4032a763ccc2a
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "react": "19.1.0",
         "react-native": "0.81.0",
-        "react-native-nitro-modules": "^0.28.0",
+        "react-native-nitro-modules": "^0.28.1",
         "react-native-safe-area-context": "^5.5.2"
     },
     "devDependencies": {

--- a/nitrogen/generated/ios/NitroFS-Swift-Cxx-Bridge.cpp
+++ b/nitrogen/generated/ios/NitroFS-Swift-Cxx-Bridge.cpp
@@ -14,7 +14,7 @@
 namespace margelo::nitro::nitrofs::bridge::swift {
 
   // pragma MARK: std::function<void(bool /* result */)>
-  Func_void_bool create_Func_void_bool(void* _Nonnull swiftClosureWrapper) {
+  Func_void_bool create_Func_void_bool(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroFS::Func_void_bool::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](bool result) mutable -> void {
       swiftClosure.call(result);
@@ -22,7 +22,7 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const std::exception_ptr& /* error */)>
-  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroFS::Func_void_std__exception_ptr::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::exception_ptr& error) mutable -> void {
       swiftClosure.call(error);
@@ -30,7 +30,7 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   }
   
   // pragma MARK: std::function<void()>
-  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) {
+  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroFS::Func_void::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)]() mutable -> void {
       swiftClosure.call();
@@ -38,7 +38,7 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const std::string& /* result */)>
-  Func_void_std__string create_Func_void_std__string(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__string create_Func_void_std__string(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroFS::Func_void_std__string::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::string& result) mutable -> void {
       swiftClosure.call(result);
@@ -46,7 +46,7 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const NitroFileStat& /* result */)>
-  Func_void_NitroFileStat create_Func_void_NitroFileStat(void* _Nonnull swiftClosureWrapper) {
+  Func_void_NitroFileStat create_Func_void_NitroFileStat(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroFS::Func_void_NitroFileStat::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const NitroFileStat& result) mutable -> void {
       swiftClosure.call(result);
@@ -54,7 +54,7 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const std::vector<std::string>& /* result */)>
-  Func_void_std__vector_std__string_ create_Func_void_std__vector_std__string_(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__vector_std__string_ create_Func_void_std__vector_std__string_(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroFS::Func_void_std__vector_std__string_::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::vector<std::string>& result) mutable -> void {
       swiftClosure.call(result);
@@ -62,7 +62,7 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   }
   
   // pragma MARK: std::function<void(double /* uploadedBytes */, double /* totalBytes */)>
-  Func_void_double_double create_Func_void_double_double(void* _Nonnull swiftClosureWrapper) {
+  Func_void_double_double create_Func_void_double_double(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroFS::Func_void_double_double::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](double uploadedBytes, double totalBytes) mutable -> void {
       swiftClosure.call(uploadedBytes, totalBytes);
@@ -70,7 +70,7 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const NitroFile& /* result */)>
-  Func_void_NitroFile create_Func_void_NitroFile(void* _Nonnull swiftClosureWrapper) {
+  Func_void_NitroFile create_Func_void_NitroFile(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroFS::Func_void_NitroFile::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const NitroFile& result) mutable -> void {
       swiftClosure.call(result);
@@ -78,11 +78,11 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   }
   
   // pragma MARK: std::shared_ptr<HybridNitroFSSpec>
-  std::shared_ptr<HybridNitroFSSpec> create_std__shared_ptr_HybridNitroFSSpec_(void* _Nonnull swiftUnsafePointer) {
+  std::shared_ptr<HybridNitroFSSpec> create_std__shared_ptr_HybridNitroFSSpec_(void* _Nonnull swiftUnsafePointer) noexcept {
     NitroFS::HybridNitroFSSpec_cxx swiftPart = NitroFS::HybridNitroFSSpec_cxx::fromUnsafe(swiftUnsafePointer);
     return std::make_shared<margelo::nitro::nitrofs::HybridNitroFSSpecSwift>(swiftPart);
   }
-  void* _Nonnull get_std__shared_ptr_HybridNitroFSSpec_(std__shared_ptr_HybridNitroFSSpec_ cppType) {
+  void* _Nonnull get_std__shared_ptr_HybridNitroFSSpec_(std__shared_ptr_HybridNitroFSSpec_ cppType) noexcept {
     std::shared_ptr<margelo::nitro::nitrofs::HybridNitroFSSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::nitrofs::HybridNitroFSSpecSwift>(cppType);
     #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {

--- a/nitrogen/generated/ios/NitroFS-Swift-Cxx-Bridge.hpp
+++ b/nitrogen/generated/ios/NitroFS-Swift-Cxx-Bridge.hpp
@@ -47,10 +47,10 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::shared_ptr<Promise<bool>>`.
    */
   using std__shared_ptr_Promise_bool__ = std::shared_ptr<Promise<bool>>;
-  inline std::shared_ptr<Promise<bool>> create_std__shared_ptr_Promise_bool__() {
+  inline std::shared_ptr<Promise<bool>> create_std__shared_ptr_Promise_bool__() noexcept {
     return Promise<bool>::create();
   }
-  inline PromiseHolder<bool> wrap_std__shared_ptr_Promise_bool__(std::shared_ptr<Promise<bool>> promise) {
+  inline PromiseHolder<bool> wrap_std__shared_ptr_Promise_bool__(std::shared_ptr<Promise<bool>> promise) noexcept {
     return PromiseHolder<bool>(std::move(promise));
   }
   
@@ -65,14 +65,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   class Func_void_bool_Wrapper final {
   public:
     explicit Func_void_bool_Wrapper(std::function<void(bool /* result */)>&& func): _function(std::make_unique<std::function<void(bool /* result */)>>(std::move(func))) {}
-    inline void call(bool result) const {
+    inline void call(bool result) const noexcept {
       _function->operator()(result);
     }
   private:
     std::unique_ptr<std::function<void(bool /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_bool create_Func_void_bool(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_bool_Wrapper wrap_Func_void_bool(Func_void_bool value) {
+  Func_void_bool create_Func_void_bool(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_bool_Wrapper wrap_Func_void_bool(Func_void_bool value) noexcept {
     return Func_void_bool_Wrapper(std::move(value));
   }
   
@@ -87,14 +87,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   class Func_void_std__exception_ptr_Wrapper final {
   public:
     explicit Func_void_std__exception_ptr_Wrapper(std::function<void(const std::exception_ptr& /* error */)>&& func): _function(std::make_unique<std::function<void(const std::exception_ptr& /* error */)>>(std::move(func))) {}
-    inline void call(std::exception_ptr error) const {
+    inline void call(std::exception_ptr error) const noexcept {
       _function->operator()(error);
     }
   private:
     std::unique_ptr<std::function<void(const std::exception_ptr& /* error */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__exception_ptr_Wrapper wrap_Func_void_std__exception_ptr(Func_void_std__exception_ptr value) {
+  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__exception_ptr_Wrapper wrap_Func_void_std__exception_ptr(Func_void_std__exception_ptr value) noexcept {
     return Func_void_std__exception_ptr_Wrapper(std::move(value));
   }
   
@@ -103,10 +103,10 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::shared_ptr<Promise<void>>`.
    */
   using std__shared_ptr_Promise_void__ = std::shared_ptr<Promise<void>>;
-  inline std::shared_ptr<Promise<void>> create_std__shared_ptr_Promise_void__() {
+  inline std::shared_ptr<Promise<void>> create_std__shared_ptr_Promise_void__() noexcept {
     return Promise<void>::create();
   }
-  inline PromiseHolder<void> wrap_std__shared_ptr_Promise_void__(std::shared_ptr<Promise<void>> promise) {
+  inline PromiseHolder<void> wrap_std__shared_ptr_Promise_void__(std::shared_ptr<Promise<void>> promise) noexcept {
     return PromiseHolder<void>(std::move(promise));
   }
   
@@ -121,14 +121,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   class Func_void_Wrapper final {
   public:
     explicit Func_void_Wrapper(std::function<void()>&& func): _function(std::make_unique<std::function<void()>>(std::move(func))) {}
-    inline void call() const {
+    inline void call() const noexcept {
       _function->operator()();
     }
   private:
     std::unique_ptr<std::function<void()>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_Wrapper wrap_Func_void(Func_void value) {
+  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_Wrapper wrap_Func_void(Func_void value) noexcept {
     return Func_void_Wrapper(std::move(value));
   }
   
@@ -137,10 +137,10 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::shared_ptr<Promise<std::string>>`.
    */
   using std__shared_ptr_Promise_std__string__ = std::shared_ptr<Promise<std::string>>;
-  inline std::shared_ptr<Promise<std::string>> create_std__shared_ptr_Promise_std__string__() {
+  inline std::shared_ptr<Promise<std::string>> create_std__shared_ptr_Promise_std__string__() noexcept {
     return Promise<std::string>::create();
   }
-  inline PromiseHolder<std::string> wrap_std__shared_ptr_Promise_std__string__(std::shared_ptr<Promise<std::string>> promise) {
+  inline PromiseHolder<std::string> wrap_std__shared_ptr_Promise_std__string__(std::shared_ptr<Promise<std::string>> promise) noexcept {
     return PromiseHolder<std::string>(std::move(promise));
   }
   
@@ -155,14 +155,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   class Func_void_std__string_Wrapper final {
   public:
     explicit Func_void_std__string_Wrapper(std::function<void(const std::string& /* result */)>&& func): _function(std::make_unique<std::function<void(const std::string& /* result */)>>(std::move(func))) {}
-    inline void call(std::string result) const {
+    inline void call(std::string result) const noexcept {
       _function->operator()(result);
     }
   private:
     std::unique_ptr<std::function<void(const std::string& /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__string create_Func_void_std__string(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__string_Wrapper wrap_Func_void_std__string(Func_void_std__string value) {
+  Func_void_std__string create_Func_void_std__string(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__string_Wrapper wrap_Func_void_std__string(Func_void_std__string value) noexcept {
     return Func_void_std__string_Wrapper(std::move(value));
   }
   
@@ -171,10 +171,10 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::shared_ptr<Promise<NitroFileStat>>`.
    */
   using std__shared_ptr_Promise_NitroFileStat__ = std::shared_ptr<Promise<NitroFileStat>>;
-  inline std::shared_ptr<Promise<NitroFileStat>> create_std__shared_ptr_Promise_NitroFileStat__() {
+  inline std::shared_ptr<Promise<NitroFileStat>> create_std__shared_ptr_Promise_NitroFileStat__() noexcept {
     return Promise<NitroFileStat>::create();
   }
-  inline PromiseHolder<NitroFileStat> wrap_std__shared_ptr_Promise_NitroFileStat__(std::shared_ptr<Promise<NitroFileStat>> promise) {
+  inline PromiseHolder<NitroFileStat> wrap_std__shared_ptr_Promise_NitroFileStat__(std::shared_ptr<Promise<NitroFileStat>> promise) noexcept {
     return PromiseHolder<NitroFileStat>(std::move(promise));
   }
   
@@ -189,14 +189,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   class Func_void_NitroFileStat_Wrapper final {
   public:
     explicit Func_void_NitroFileStat_Wrapper(std::function<void(const NitroFileStat& /* result */)>&& func): _function(std::make_unique<std::function<void(const NitroFileStat& /* result */)>>(std::move(func))) {}
-    inline void call(NitroFileStat result) const {
+    inline void call(NitroFileStat result) const noexcept {
       _function->operator()(result);
     }
   private:
     std::unique_ptr<std::function<void(const NitroFileStat& /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_NitroFileStat create_Func_void_NitroFileStat(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_NitroFileStat_Wrapper wrap_Func_void_NitroFileStat(Func_void_NitroFileStat value) {
+  Func_void_NitroFileStat create_Func_void_NitroFileStat(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_NitroFileStat_Wrapper wrap_Func_void_NitroFileStat(Func_void_NitroFileStat value) noexcept {
     return Func_void_NitroFileStat_Wrapper(std::move(value));
   }
   
@@ -205,7 +205,7 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::vector<std::string>`.
    */
   using std__vector_std__string_ = std::vector<std::string>;
-  inline std::vector<std::string> create_std__vector_std__string_(size_t size) {
+  inline std::vector<std::string> create_std__vector_std__string_(size_t size) noexcept {
     std::vector<std::string> vector;
     vector.reserve(size);
     return vector;
@@ -216,10 +216,10 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::shared_ptr<Promise<std::vector<std::string>>>`.
    */
   using std__shared_ptr_Promise_std__vector_std__string___ = std::shared_ptr<Promise<std::vector<std::string>>>;
-  inline std::shared_ptr<Promise<std::vector<std::string>>> create_std__shared_ptr_Promise_std__vector_std__string___() {
+  inline std::shared_ptr<Promise<std::vector<std::string>>> create_std__shared_ptr_Promise_std__vector_std__string___() noexcept {
     return Promise<std::vector<std::string>>::create();
   }
-  inline PromiseHolder<std::vector<std::string>> wrap_std__shared_ptr_Promise_std__vector_std__string___(std::shared_ptr<Promise<std::vector<std::string>>> promise) {
+  inline PromiseHolder<std::vector<std::string>> wrap_std__shared_ptr_Promise_std__vector_std__string___(std::shared_ptr<Promise<std::vector<std::string>>> promise) noexcept {
     return PromiseHolder<std::vector<std::string>>(std::move(promise));
   }
   
@@ -234,14 +234,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   class Func_void_std__vector_std__string__Wrapper final {
   public:
     explicit Func_void_std__vector_std__string__Wrapper(std::function<void(const std::vector<std::string>& /* result */)>&& func): _function(std::make_unique<std::function<void(const std::vector<std::string>& /* result */)>>(std::move(func))) {}
-    inline void call(std::vector<std::string> result) const {
+    inline void call(std::vector<std::string> result) const noexcept {
       _function->operator()(result);
     }
   private:
     std::unique_ptr<std::function<void(const std::vector<std::string>& /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__vector_std__string_ create_Func_void_std__vector_std__string_(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__vector_std__string__Wrapper wrap_Func_void_std__vector_std__string_(Func_void_std__vector_std__string_ value) {
+  Func_void_std__vector_std__string_ create_Func_void_std__vector_std__string_(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__vector_std__string__Wrapper wrap_Func_void_std__vector_std__string_(Func_void_std__vector_std__string_ value) noexcept {
     return Func_void_std__vector_std__string__Wrapper(std::move(value));
   }
   
@@ -250,8 +250,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::optional<std::string>`.
    */
   using std__optional_std__string_ = std::optional<std::string>;
-  inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) {
+  inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) noexcept {
     return std::optional<std::string>(value);
+  }
+  inline bool has_value_std__optional_std__string_(const std::optional<std::string>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline std::string get_std__optional_std__string_(const std::optional<std::string>& optional) noexcept {
+    return *optional;
   }
   
   // pragma MARK: std::optional<NitroUploadMethod>
@@ -259,8 +265,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::optional<NitroUploadMethod>`.
    */
   using std__optional_NitroUploadMethod_ = std::optional<NitroUploadMethod>;
-  inline std::optional<NitroUploadMethod> create_std__optional_NitroUploadMethod_(const NitroUploadMethod& value) {
+  inline std::optional<NitroUploadMethod> create_std__optional_NitroUploadMethod_(const NitroUploadMethod& value) noexcept {
     return std::optional<NitroUploadMethod>(value);
+  }
+  inline bool has_value_std__optional_NitroUploadMethod_(const std::optional<NitroUploadMethod>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline NitroUploadMethod get_std__optional_NitroUploadMethod_(const std::optional<NitroUploadMethod>& optional) noexcept {
+    return *optional;
   }
   
   // pragma MARK: std::function<void(double /* uploadedBytes */, double /* totalBytes */)>
@@ -274,14 +286,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   class Func_void_double_double_Wrapper final {
   public:
     explicit Func_void_double_double_Wrapper(std::function<void(double /* uploadedBytes */, double /* totalBytes */)>&& func): _function(std::make_unique<std::function<void(double /* uploadedBytes */, double /* totalBytes */)>>(std::move(func))) {}
-    inline void call(double uploadedBytes, double totalBytes) const {
+    inline void call(double uploadedBytes, double totalBytes) const noexcept {
       _function->operator()(uploadedBytes, totalBytes);
     }
   private:
     std::unique_ptr<std::function<void(double /* uploadedBytes */, double /* totalBytes */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_double_double create_Func_void_double_double(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_double_double_Wrapper wrap_Func_void_double_double(Func_void_double_double value) {
+  Func_void_double_double create_Func_void_double_double(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_double_double_Wrapper wrap_Func_void_double_double(Func_void_double_double value) noexcept {
     return Func_void_double_double_Wrapper(std::move(value));
   }
   
@@ -290,8 +302,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::optional<std::function<void(double / * uploadedBytes * /, double / * totalBytes * /)>>`.
    */
   using std__optional_std__function_void_double____uploadedBytes_____double____totalBytes______ = std::optional<std::function<void(double /* uploadedBytes */, double /* totalBytes */)>>;
-  inline std::optional<std::function<void(double /* uploadedBytes */, double /* totalBytes */)>> create_std__optional_std__function_void_double____uploadedBytes_____double____totalBytes______(const std::function<void(double /* uploadedBytes */, double /* totalBytes */)>& value) {
+  inline std::optional<std::function<void(double /* uploadedBytes */, double /* totalBytes */)>> create_std__optional_std__function_void_double____uploadedBytes_____double____totalBytes______(const std::function<void(double /* uploadedBytes */, double /* totalBytes */)>& value) noexcept {
     return std::optional<std::function<void(double /* uploadedBytes */, double /* totalBytes */)>>(value);
+  }
+  inline bool has_value_std__optional_std__function_void_double____uploadedBytes_____double____totalBytes______(const std::optional<std::function<void(double /* uploadedBytes */, double /* totalBytes */)>>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline std::function<void(double /* uploadedBytes */, double /* totalBytes */)> get_std__optional_std__function_void_double____uploadedBytes_____double____totalBytes______(const std::optional<std::function<void(double /* uploadedBytes */, double /* totalBytes */)>>& optional) noexcept {
+    return *optional;
   }
   
   // pragma MARK: std::shared_ptr<Promise<NitroFile>>
@@ -299,10 +317,10 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::shared_ptr<Promise<NitroFile>>`.
    */
   using std__shared_ptr_Promise_NitroFile__ = std::shared_ptr<Promise<NitroFile>>;
-  inline std::shared_ptr<Promise<NitroFile>> create_std__shared_ptr_Promise_NitroFile__() {
+  inline std::shared_ptr<Promise<NitroFile>> create_std__shared_ptr_Promise_NitroFile__() noexcept {
     return Promise<NitroFile>::create();
   }
-  inline PromiseHolder<NitroFile> wrap_std__shared_ptr_Promise_NitroFile__(std::shared_ptr<Promise<NitroFile>> promise) {
+  inline PromiseHolder<NitroFile> wrap_std__shared_ptr_Promise_NitroFile__(std::shared_ptr<Promise<NitroFile>> promise) noexcept {
     return PromiseHolder<NitroFile>(std::move(promise));
   }
   
@@ -317,14 +335,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
   class Func_void_NitroFile_Wrapper final {
   public:
     explicit Func_void_NitroFile_Wrapper(std::function<void(const NitroFile& /* result */)>&& func): _function(std::make_unique<std::function<void(const NitroFile& /* result */)>>(std::move(func))) {}
-    inline void call(NitroFile result) const {
+    inline void call(NitroFile result) const noexcept {
       _function->operator()(result);
     }
   private:
     std::unique_ptr<std::function<void(const NitroFile& /* result */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_NitroFile create_Func_void_NitroFile(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_NitroFile_Wrapper wrap_Func_void_NitroFile(Func_void_NitroFile value) {
+  Func_void_NitroFile create_Func_void_NitroFile(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_NitroFile_Wrapper wrap_Func_void_NitroFile(Func_void_NitroFile value) noexcept {
     return Func_void_NitroFile_Wrapper(std::move(value));
   }
   
@@ -333,8 +351,14 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::optional<std::function<void(double / * downloadedBytes * /, double / * totalBytes * /)>>`.
    */
   using std__optional_std__function_void_double____downloadedBytes_____double____totalBytes______ = std::optional<std::function<void(double /* downloadedBytes */, double /* totalBytes */)>>;
-  inline std::optional<std::function<void(double /* downloadedBytes */, double /* totalBytes */)>> create_std__optional_std__function_void_double____downloadedBytes_____double____totalBytes______(const std::function<void(double /* downloadedBytes */, double /* totalBytes */)>& value) {
+  inline std::optional<std::function<void(double /* downloadedBytes */, double /* totalBytes */)>> create_std__optional_std__function_void_double____downloadedBytes_____double____totalBytes______(const std::function<void(double /* downloadedBytes */, double /* totalBytes */)>& value) noexcept {
     return std::optional<std::function<void(double /* downloadedBytes */, double /* totalBytes */)>>(value);
+  }
+  inline bool has_value_std__optional_std__function_void_double____downloadedBytes_____double____totalBytes______(const std::optional<std::function<void(double /* downloadedBytes */, double /* totalBytes */)>>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline std::function<void(double /* downloadedBytes */, double /* totalBytes */)> get_std__optional_std__function_void_double____downloadedBytes_____double____totalBytes______(const std::optional<std::function<void(double /* downloadedBytes */, double /* totalBytes */)>>& optional) noexcept {
+    return *optional;
   }
   
   // pragma MARK: std::shared_ptr<HybridNitroFSSpec>
@@ -342,73 +366,73 @@ namespace margelo::nitro::nitrofs::bridge::swift {
    * Specialized version of `std::shared_ptr<HybridNitroFSSpec>`.
    */
   using std__shared_ptr_HybridNitroFSSpec_ = std::shared_ptr<HybridNitroFSSpec>;
-  std::shared_ptr<HybridNitroFSSpec> create_std__shared_ptr_HybridNitroFSSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_HybridNitroFSSpec_(std__shared_ptr_HybridNitroFSSpec_ cppType);
+  std::shared_ptr<HybridNitroFSSpec> create_std__shared_ptr_HybridNitroFSSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
+  void* _Nonnull get_std__shared_ptr_HybridNitroFSSpec_(std__shared_ptr_HybridNitroFSSpec_ cppType) noexcept;
   
   // pragma MARK: std::weak_ptr<HybridNitroFSSpec>
   using std__weak_ptr_HybridNitroFSSpec_ = std::weak_ptr<HybridNitroFSSpec>;
-  inline std__weak_ptr_HybridNitroFSSpec_ weakify_std__shared_ptr_HybridNitroFSSpec_(const std::shared_ptr<HybridNitroFSSpec>& strong) { return strong; }
+  inline std__weak_ptr_HybridNitroFSSpec_ weakify_std__shared_ptr_HybridNitroFSSpec_(const std::shared_ptr<HybridNitroFSSpec>& strong) noexcept { return strong; }
   
   // pragma MARK: Result<std::shared_ptr<Promise<bool>>>
   using Result_std__shared_ptr_Promise_bool___ = Result<std::shared_ptr<Promise<bool>>>;
-  inline Result_std__shared_ptr_Promise_bool___ create_Result_std__shared_ptr_Promise_bool___(const std::shared_ptr<Promise<bool>>& value) {
+  inline Result_std__shared_ptr_Promise_bool___ create_Result_std__shared_ptr_Promise_bool___(const std::shared_ptr<Promise<bool>>& value) noexcept {
     return Result<std::shared_ptr<Promise<bool>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_bool___ create_Result_std__shared_ptr_Promise_bool___(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_bool___ create_Result_std__shared_ptr_Promise_bool___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<bool>>>::withError(error);
   }
   
   // pragma MARK: Result<std::shared_ptr<Promise<void>>>
   using Result_std__shared_ptr_Promise_void___ = Result<std::shared_ptr<Promise<void>>>;
-  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::shared_ptr<Promise<void>>& value) {
+  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::shared_ptr<Promise<void>>& value) noexcept {
     return Result<std::shared_ptr<Promise<void>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<void>>>::withError(error);
   }
   
   // pragma MARK: Result<std::shared_ptr<Promise<std::string>>>
   using Result_std__shared_ptr_Promise_std__string___ = Result<std::shared_ptr<Promise<std::string>>>;
-  inline Result_std__shared_ptr_Promise_std__string___ create_Result_std__shared_ptr_Promise_std__string___(const std::shared_ptr<Promise<std::string>>& value) {
+  inline Result_std__shared_ptr_Promise_std__string___ create_Result_std__shared_ptr_Promise_std__string___(const std::shared_ptr<Promise<std::string>>& value) noexcept {
     return Result<std::shared_ptr<Promise<std::string>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_std__string___ create_Result_std__shared_ptr_Promise_std__string___(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_std__string___ create_Result_std__shared_ptr_Promise_std__string___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<std::string>>>::withError(error);
   }
   
   // pragma MARK: Result<std::shared_ptr<Promise<NitroFileStat>>>
   using Result_std__shared_ptr_Promise_NitroFileStat___ = Result<std::shared_ptr<Promise<NitroFileStat>>>;
-  inline Result_std__shared_ptr_Promise_NitroFileStat___ create_Result_std__shared_ptr_Promise_NitroFileStat___(const std::shared_ptr<Promise<NitroFileStat>>& value) {
+  inline Result_std__shared_ptr_Promise_NitroFileStat___ create_Result_std__shared_ptr_Promise_NitroFileStat___(const std::shared_ptr<Promise<NitroFileStat>>& value) noexcept {
     return Result<std::shared_ptr<Promise<NitroFileStat>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_NitroFileStat___ create_Result_std__shared_ptr_Promise_NitroFileStat___(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_NitroFileStat___ create_Result_std__shared_ptr_Promise_NitroFileStat___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<NitroFileStat>>>::withError(error);
   }
   
   // pragma MARK: Result<std::shared_ptr<Promise<std::vector<std::string>>>>
   using Result_std__shared_ptr_Promise_std__vector_std__string____ = Result<std::shared_ptr<Promise<std::vector<std::string>>>>;
-  inline Result_std__shared_ptr_Promise_std__vector_std__string____ create_Result_std__shared_ptr_Promise_std__vector_std__string____(const std::shared_ptr<Promise<std::vector<std::string>>>& value) {
+  inline Result_std__shared_ptr_Promise_std__vector_std__string____ create_Result_std__shared_ptr_Promise_std__vector_std__string____(const std::shared_ptr<Promise<std::vector<std::string>>>& value) noexcept {
     return Result<std::shared_ptr<Promise<std::vector<std::string>>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_std__vector_std__string____ create_Result_std__shared_ptr_Promise_std__vector_std__string____(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_std__vector_std__string____ create_Result_std__shared_ptr_Promise_std__vector_std__string____(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<std::vector<std::string>>>>::withError(error);
   }
   
   // pragma MARK: Result<std::string>
   using Result_std__string_ = Result<std::string>;
-  inline Result_std__string_ create_Result_std__string_(const std::string& value) {
+  inline Result_std__string_ create_Result_std__string_(const std::string& value) noexcept {
     return Result<std::string>::withValue(value);
   }
-  inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) {
+  inline Result_std__string_ create_Result_std__string_(const std::exception_ptr& error) noexcept {
     return Result<std::string>::withError(error);
   }
   
   // pragma MARK: Result<std::shared_ptr<Promise<NitroFile>>>
   using Result_std__shared_ptr_Promise_NitroFile___ = Result<std::shared_ptr<Promise<NitroFile>>>;
-  inline Result_std__shared_ptr_Promise_NitroFile___ create_Result_std__shared_ptr_Promise_NitroFile___(const std::shared_ptr<Promise<NitroFile>>& value) {
+  inline Result_std__shared_ptr_Promise_NitroFile___ create_Result_std__shared_ptr_Promise_NitroFile___(const std::shared_ptr<Promise<NitroFile>>& value) noexcept {
     return Result<std::shared_ptr<Promise<NitroFile>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_NitroFile___ create_Result_std__shared_ptr_Promise_NitroFile___(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_NitroFile___ create_Result_std__shared_ptr_Promise_NitroFile___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<NitroFile>>>::withError(error);
   }
 

--- a/nitrogen/generated/ios/swift/HybridNitroFSSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroFSSpec_cxx.swift
@@ -347,7 +347,8 @@ open class HybridNitroFSSpec_cxx {
   public final func basename(path: std.string, ext: bridge.std__optional_std__string_) -> bridge.Result_std__string_ {
     do {
       let __result = try self.__implementation.basename(path: String(path), ext: { () -> String? in
-        if let __unwrapped = ext.value {
+        if bridge.has_value_std__optional_std__string_(ext) {
+          let __unwrapped = bridge.get_std__optional_std__string_(ext)
           return String(__unwrapped)
         } else {
           return nil
@@ -377,7 +378,8 @@ open class HybridNitroFSSpec_cxx {
   public final func uploadFile(file: NitroFile, uploadOptions: NitroUploadOptions, onProgress: bridge.std__optional_std__function_void_double____uploadedBytes_____double____totalBytes______) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
       let __result = try self.__implementation.uploadFile(file: file, uploadOptions: uploadOptions, onProgress: { () -> ((_ uploadedBytes: Double, _ totalBytes: Double) -> Void)? in
-        if let __unwrapped = onProgress.value {
+        if bridge.has_value_std__optional_std__function_void_double____uploadedBytes_____double____totalBytes______(onProgress) {
+          let __unwrapped = bridge.get_std__optional_std__function_void_double____uploadedBytes_____double____totalBytes______(onProgress)
           return { () -> (Double, Double) -> Void in
             let __wrappedFunction = bridge.wrap_Func_void_double_double(__unwrapped)
             return { (__uploadedBytes: Double, __totalBytes: Double) -> Void in
@@ -407,7 +409,8 @@ open class HybridNitroFSSpec_cxx {
   public final func downloadFile(serverUrl: std.string, destinationPath: std.string, onProgress: bridge.std__optional_std__function_void_double____downloadedBytes_____double____totalBytes______) -> bridge.Result_std__shared_ptr_Promise_NitroFile___ {
     do {
       let __result = try self.__implementation.downloadFile(serverUrl: String(serverUrl), destinationPath: String(destinationPath), onProgress: { () -> ((_ downloadedBytes: Double, _ totalBytes: Double) -> Void)? in
-        if let __unwrapped = onProgress.value {
+        if bridge.has_value_std__optional_std__function_void_double____downloadedBytes_____double____totalBytes______(onProgress) {
+          let __unwrapped = bridge.get_std__optional_std__function_void_double____downloadedBytes_____double____totalBytes______(onProgress)
           return { () -> (Double, Double) -> Void in
             let __wrappedFunction = bridge.wrap_Func_void_double_double(__unwrapped)
             return { (__downloadedBytes: Double, __totalBytes: Double) -> Void in

--- a/nitrogen/generated/ios/swift/NitroUploadOptions.swift
+++ b/nitrogen/generated/ios/swift/NitroUploadOptions.swift
@@ -66,7 +66,8 @@ public extension NitroUploadOptions {
     @inline(__always)
     get {
       return { () -> String? in
-        if let __unwrapped = self.__field.value {
+        if bridge.has_value_std__optional_std__string_(self.__field) {
+          let __unwrapped = bridge.get_std__optional_std__string_(self.__field)
           return String(__unwrapped)
         } else {
           return nil

--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
         "@types/jest": "^29.5.12",
         "@types/react": "^19.1.0",
         "conventional-changelog-conventionalcommits": "^9.1.0",
-        "nitro-codegen": "^0.28.0",
+        "nitro-codegen": "^0.28.1",
         "react": "19.1.0",
         "react-native": "0.81.0",
         "react-native-builder-bob": "^0.37.0",
-        "react-native-nitro-modules": "^0.28.0",
+        "react-native-nitro-modules": "^0.28.1",
         "semantic-release": "^24.2.7",
         "typescript": "^5.8.3"
     },


### PR DESCRIPTION
Bumps nitro-codegen and react-native-nitro-modules from 0.28.0 to 0.28.1 in package.json and bun.lock. Updates README and example package.json to reflect the latest version. Additionally, updates Podfile.lock to use NitroModules 0.28.1 and NitroFS 0.6.1.

- Updated dependencies in package.json and bun.lock
- Adjusted installation commands in README
- Updated example project dependencies
- Updated iOS Podfile.lock for NitroModules and NitroFS versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Simplified installation instructions by removing the pinned version for react-native-nitro-modules, so package managers install the latest compatible release.

- Chores
  - Updated dependencies to maintain compatibility and stability:
    - example app: react-native-nitro-modules to ^0.28.1.
    - root devDependencies: nitro-codegen and react-native-nitro-modules to ^0.28.1.
  - No functional changes or API updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->