### PR TITLE
fix(android): Point document/download dirs to app-scoped storage

### DIFF
--- a/android/src/main/java/com/nitrofs/HybridNitroFS.kt
+++ b/android/src/main/java/com/nitrofs/HybridNitroFS.kt
@@ -41,7 +41,7 @@ class HybridNitroFS: HybridNitroFSSpec() {
             try {
                 nitroFsImpl.writeFile(path, data, encoding)
             } catch (e: Exception) {
-                Log.e("NitroFS", "Error writing file: ${e.message}")
+                Log.e(TAG, "Error writing file: ${e.message}")
                 throw Error(e)
             }
         }
@@ -55,7 +55,7 @@ class HybridNitroFS: HybridNitroFSSpec() {
             try {
                 nitroFsImpl.readFile(path, encoding)
             } catch (e: Exception) {
-                Log.e("NitroFS", "Error reading file: ${e.message}")
+                Log.e(TAG, "Error reading file: ${e.message}")
                 throw Error(e)
             }
         }
@@ -69,7 +69,7 @@ class HybridNitroFS: HybridNitroFSSpec() {
             try {
                 nitroFsImpl.copyFile(srcPath, destPath)
             } catch (e: Exception) {
-                Log.e("NitroFS", "Error copying file: ${e.message}")
+                Log.e(TAG, "Error copying file: ${e.message}")
                 throw Error(e)
             }
         }
@@ -87,7 +87,7 @@ class HybridNitroFS: HybridNitroFSSpec() {
             try {
                 nitroFsImpl.unlink(path)
             } catch (e: Exception) {
-                Log.e("NitroFS", "Error unlinking file: ${e.message}")
+                Log.e(TAG, "Error unlinking file: ${e.message}")
                 throw Error(e)
             }
         }
@@ -98,7 +98,7 @@ class HybridNitroFS: HybridNitroFSSpec() {
             try {
                 nitroFsImpl.mkdir(path)
             } catch (e: Exception) {
-                Log.e("NitroFS", "Error creating directory: ${e.message}")
+                Log.e(TAG, "Error creating directory: ${e.message}")
                 throw Error(e)
             }
         }

--- a/android/src/main/java/com/nitrofs/NitroFSImpl.kt
+++ b/android/src/main/java/com/nitrofs/NitroFSImpl.kt
@@ -188,7 +188,7 @@ class NitroFSImpl(val context: ReactApplicationContext) {
     }
 
     fun getDocumentDir(): String {
-        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)?.absolutePath ?: ""
+        return context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)?.absolutePath ?: ""
     }
 
     fun getCacheDir(): String {
@@ -196,7 +196,7 @@ class NitroFSImpl(val context: ReactApplicationContext) {
     }
 
     fun getDownloadDir(): String {
-        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)?.absolutePath ?: ""
+        return context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)?.absolutePath ?: ""
     }
 
     suspend fun uploadFile(file: NitroFile,

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "react-native-nitro-fs",

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2677,7 +2677,7 @@ SPEC CHECKSUMS:
   React-timing: 25e8229ad1cf6874e9f0711515213cb2bc322215
   React-utils: 068cec677032ba78ca0700f2dcbe6d08a0939647
   ReactAppDependencyProvider: c91900fa724baee992f01c05eeb4c9e01a807f78
-  ReactCodegen: 54a2215641cfa5cd551ab2ef6218b94c9b4979e3
+  ReactCodegen: c3a2e945d68bcf8839624acaf1b276acbb41e9ba
   ReactCommon: 116d6ee71679243698620d8cd9a9042541e44aa6
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 00013dd9cde63a2d98e8002fcc4f5ddb66c10782


### PR DESCRIPTION
Fixes #115 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal logging consistency.

* **Changes**
  * Updated document and download storage locations to use app-specific directories. Files may now be stored and accessed differently than before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->