### PR TITLE
Android 16kb conditional linking options for NDK version

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -21,6 +21,10 @@ include_directories(
 
 find_library(LOG_LIB log)
 
+if(CMAKE_ANDROID_NDK_VERSION VERSION_LESS "27")
+    target_link_options(${PACKAGE_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
+endif()
+
 # Link all libraries together
 target_link_libraries(
         ${PACKAGE_NAME}


### PR DESCRIPTION
Version 0.8.0 does not correctly aligns the library
<img width="296" height="42" alt="image" src="https://github.com/user-attachments/assets/3256918c-f165-4eea-9a57-77c15a75af88" />

While the previous commit 8431cb0 added the `DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES` flag for build gradle, check_elf still marked the library as unresolved. I added this on my project as a patch and it did build correctly and the debug warning is away and check_elf verifies that it is correctly packed. 

This pull request introduces a conditional linker flag for Android builds in the `android/CMakeLists.txt` file. The change ensures compatibility with older Android NDK versions by setting the maximum page size in the linker options when using NDK versions earlier than 27.

Build system compatibility:

* Adds a conditional statement to set the linker flag `-Wl,-z,max-page-size=16384` for NDK versions less than 27 to address compatibility issues with memory page sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build compatibility with older Android NDK versions through conditional linker configuration adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->